### PR TITLE
GameBoard Entity 버그 수정

### DIFF
--- a/server/src/main/java/knu/nono/yesgram/domain/GameBoard.java
+++ b/server/src/main/java/knu/nono/yesgram/domain/GameBoard.java
@@ -1,13 +1,14 @@
 package knu.nono.yesgram.domain;
 
-import lombok.*;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
 
 import javax.persistence.*;
 
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-@AllArgsConstructor
-@Builder
 @Entity
 @Table(name = "game_boards")
 public class GameBoard {
@@ -17,11 +18,12 @@ public class GameBoard {
 	private Long id;
 	
 	@Column(nullable = false)
-	private Integer size;
+	private int size;
 
 	@Column(nullable = false)
 	private String answer;
 	
 	@Setter
+	@Transient
 	private boolean cleared;
 }


### PR DESCRIPTION
#9

- @Transient 어노테이션을 추가해서, cleared 필드가 DB에 반영되지 않도록 함
- 불필요한 랩퍼 클래스를 제거